### PR TITLE
feat(advanced search): Add support for multiple antivirus engines and field groups in search queries

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -303,6 +303,24 @@ func (db *DB) Search(ctx context.Context, stringQuery string, val *interface{}, 
 			"fsecure": {
 				Field: "multiav.last_scan.fsecure.output",
 			},
+			"engines": {
+				FieldGroup: []string{
+					"multiav.last_scan.avast.output",
+					"multiav.last_scan.avira.output",
+					"multiav.last_scan.bitdefender.output",
+					"multiav.last_scan.clamav.output",
+					"multiav.last_scan.comodo.output",
+					"multiav.last_scan.drweb.output",
+					"multiav.last_scan.eset.output",
+					"multiav.last_scan.kaspersky.output",
+					"multiav.last_scan.mcafee.output",
+					"multiav.last_scan.sophos.output",
+					"multiav.last_scan.symantec.output",
+					"multiav.last_scan.trendmicro.output",
+					"multiav.last_scan.windefender.output",
+					"multiav.last_scan.fsecure.output",
+				},
+			},
 		},
 	)
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -262,46 +262,46 @@ func (db *DB) Search(ctx context.Context, stringQuery string, val *interface{}, 
 				Type: gen.NUMBER,
 			},
 			"avast": {
-				Path: "multiav.last_scan.avast.output",
+				Field: "multiav.last_scan.avast.output",
 			},
 			"avira": {
-				Path: "multiav.last_scan.avira.output",
+				Field: "multiav.last_scan.avira.output",
 			},
 			"bitdefender": {
-				Path: "multiav.last_scan.bitdefender.output",
+				Field: "multiav.last_scan.bitdefender.output",
 			},
 			"clamav": {
-				Path: "multiav.last_scan.clamav.output",
+				Field: "multiav.last_scan.clamav.output",
 			},
 			"comodo": {
-				Path: "multiav.last_scan.comodo.output",
+				Field: "multiav.last_scan.comodo.output",
 			},
 			"drweb": {
-				Path: "multiav.last_scan.drweb.output",
+				Field: "multiav.last_scan.drweb.output",
 			},
 			"eset": {
-				Path: "multiav.last_scan.eset.output",
+				Field: "multiav.last_scan.eset.output",
 			},
 			"kaspersky": {
-				Path: "multiav.last_scan.kaspersky.output",
+				Field: "multiav.last_scan.kaspersky.output",
 			},
 			"mcafee": {
-				Path: "multiav.last_scan.mcafee.output",
+				Field: "multiav.last_scan.mcafee.output",
 			},
 			"sophos": {
-				Path: "multiav.last_scan.sophos.output",
+				Field: "multiav.last_scan.sophos.output",
 			},
 			"symantec": {
-				Path: "multiav.last_scan.symantec.output",
+				Field: "multiav.last_scan.symantec.output",
 			},
 			"trendmicro": {
-				Path: "multiav.last_scan.trendmicro.output",
+				Field: "multiav.last_scan.trendmicro.output",
 			},
 			"windefender": {
-				Path: "multiav.last_scan.windefender.output",
+				Field: "multiav.last_scan.windefender.output",
 			},
 			"fsecure": {
-				Path: "multiav.last_scan.fsecure.output",
+				Field: "multiav.last_scan.fsecure.output",
 			},
 		},
 	)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -255,9 +255,27 @@ func (db *DB) Search(ctx context.Context, stringQuery string, val *interface{}, 
 			"first_seen": {
 				Type: gen.DATE,
 			},
+			"fs": {
+				Type:  gen.DATE,
+				Field: "first_seen",
+			},
+
 			"last_scanned": {
 				Type: gen.DATE,
 			},
+			"ls": {
+				Type:  gen.DATE,
+				Field: "last_scanned",
+			},
+
+			"extension": {
+				Field: "file_extension",
+			},
+
+			"type": {
+				Field: "file_format",
+			},
+
 			"size": {
 				Type: gen.NUMBER,
 			},

--- a/internal/query-parser/gen/gen.go
+++ b/internal/query-parser/gen/gen.go
@@ -14,7 +14,8 @@ import (
 type Type int
 
 // Key is the identifier which can map to one or multiple fields
-// if none is provided it's assumed that the field is the identifier
+// if none is provided it's assumed that the field is the identifier.
+// if Type is not provided it's assumed to be a string.
 type Config map[string]struct {
 	Type       Type
 	Field      string

--- a/internal/query-parser/gen/gen.go
+++ b/internal/query-parser/gen/gen.go
@@ -13,9 +13,12 @@ import (
 
 type Type int
 
+// Key is the identifier which can map to one or multiple fields
+// if none is provided it's assumed that the field is the identifier
 type Config map[string]struct {
-	Type Type
-	Path string
+	Type       Type
+	Field      string
+	FieldGroup []string
 }
 
 const (
@@ -39,6 +42,11 @@ func Generate(input string, cfg Config) (search.Query, error) {
 		return nil, err
 	}
 
+	for _, v := range cfg {
+		if v.Field != "" && len(v.FieldGroup) != 0 {
+			panic("config can not have path and path group at the same time")
+		}
+	}
 	config = cfg
 	result, err := GenerateCouchbaseFTS(expr)
 	if err != nil {
@@ -81,41 +89,53 @@ func generateBinaryCouchbase(expr *parser.BinaryExpression) (search.Query, error
 }
 
 func generateComparisonCouchbase(expr *parser.ComparisonExpression) (search.Query, error) {
-	// NOTE: might need to support term match query
-	field := expr.Left
-	if v, ok := config[expr.Left]; ok {
-		if v.Path != "" {
-			field = v.Path
+	if len(config[expr.Left].FieldGroup) != 0 {
+		var queries search.Query
+		for _, field := range config[expr.Left].FieldGroup {
+			query, err := buildComparisonQuery(field, expr.Right, expr.Operator.Type, config[expr.Left].Type)
+			if err != nil {
+				return nil, err
+			}
+
+			if queries == nil {
+				queries = query
+			} else {
+				queries = search.NewDisjunctionQuery(query, queries)
+			}
 		}
+		return queries, nil
 	}
 
-	switch expr.Operator.Type {
+	identifier := expr.Left
+	field := identifier
+	if v, ok := config[identifier]; ok && v.Field != "" {
+		field = v.Field
+	}
+
+	valueType := config[expr.Left].Type
+
+	return buildComparisonQuery(field, expr.Right, expr.Operator.Type, valueType)
+}
+
+func buildComparisonQuery(field, value string, operator token.TokenType, valueType Type) (search.Query, error) {
+	switch operator {
 	case token.ASSIGN:
-		return search.NewMatchQuery(expr.Right).Field(field), nil
+		// NOTE: might need to support term match query
+		return search.NewMatchQuery(value).Field(field), nil
 	case token.NOT_EQ:
-		return search.NewBooleanQuery().MustNot(search.NewMatchQuery(expr.Right).Field(field)), nil
+		return search.NewBooleanQuery().MustNot(search.NewMatchQuery(value).Field(field)), nil
 	case token.GT, token.GE, token.LT, token.LE:
-		return generateRangeQuery(expr)
+		return buildRangeQuery(field, value, operator, valueType)
 	default:
-		return nil, fmt.Errorf("unsupported comparison operator: %s", expr.Operator.Type)
+		return nil, fmt.Errorf("unsupported comparison operator: %s", operator)
 	}
 }
 
-func generateRangeQuery(expr *parser.ComparisonExpression) (search.Query, error) {
-	field := expr.Left
-	if v, ok := config[expr.Left]; ok {
-		if v.Path != "" {
-			field = v.Path
-		}
-	}
-	value := expr.Right
-
-	t := config[expr.Left].Type
-
-	isInclusive := expr.Operator.Type == token.GE || expr.Operator.Type == token.LE
-	switch expr.Operator.Type {
+func buildRangeQuery(field, value string, operator token.TokenType, valueType Type) (search.Query, error) {
+	isInclusive := operator == token.GE || operator == token.LE
+	switch operator {
 	case token.GT, token.GE:
-		switch t {
+		switch valueType {
 		case NUMBER:
 			v, err := strconv.ParseFloat(value, 32)
 			if err != nil {
@@ -133,7 +153,7 @@ func generateRangeQuery(expr *parser.ComparisonExpression) (search.Query, error)
 		}
 
 	case token.LT, token.LE:
-		switch t {
+		switch valueType {
 		case NUMBER:
 			num, err := strconv.ParseFloat(value, 32)
 			if err != nil {
@@ -151,7 +171,7 @@ func generateRangeQuery(expr *parser.ComparisonExpression) (search.Query, error)
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported range operator: %s", expr.Operator.Type)
+	return nil, fmt.Errorf("unsupported range operator: %s", operator)
 }
 
 func isValidF32(s string) (float32, bool) {

--- a/internal/query-parser/gen/gen.go
+++ b/internal/query-parser/gen/gen.go
@@ -90,20 +90,16 @@ func generateBinaryCouchbase(expr *parser.BinaryExpression) (search.Query, error
 
 func generateComparisonCouchbase(expr *parser.ComparisonExpression) (search.Query, error) {
 	if len(config[expr.Left].FieldGroup) != 0 {
-		var queries search.Query
+		queries := []search.Query{}
 		for _, field := range config[expr.Left].FieldGroup {
 			query, err := buildComparisonQuery(field, expr.Right, expr.Operator.Type, config[expr.Left].Type)
 			if err != nil {
 				return nil, err
 			}
 
-			if queries == nil {
-				queries = query
-			} else {
-				queries = search.NewDisjunctionQuery(query, queries)
-			}
+			queries = append(queries, query)
 		}
-		return queries, nil
+		return search.NewDisjunctionQuery(queries...), nil
 	}
 
 	identifier := expr.Left

--- a/internal/query-parser/gen/gen_test.go
+++ b/internal/query-parser/gen/gen_test.go
@@ -246,6 +246,17 @@ func TestGenerate(t *testing.T) {
 				search.NewNumericRangeQuery().Field("size").Min(float32(1000), false),
 			),
 		},
+		{
+			name:  "field alias",
+			input: "fs>=2023-01-01",
+			config: Config{
+				"fs": {
+					Type:  DATE,
+					Field: "first_seen",
+				},
+			},
+			wanted: search.NewNumericRangeQuery().Field("first_seen").Min(float32(1672531200), true),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Introduce support for field groups in the configuration, allowing multiple antivirus engines to be queried simultaneously. Simplify query generation logic and clarify documentation for better understanding.