### PR TITLE
feat(advanced search): Add support for relative time units in date queries

### DIFF
--- a/internal/query-parser/gen/gen_test.go
+++ b/internal/query-parser/gen/gen_test.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocb/v2/search"
 	"github.com/stretchr/testify/assert"
@@ -267,6 +268,50 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			wanted: search.NewNumericRangeQuery().Field("first_seen").Min(float32(1704067200), true),
+		},
+		{
+			name:  "test relative time with hours",
+			input: "fs <= 24h",
+			config: Config{
+				"fs": {
+					Type:  DATE,
+					Field: "first_seen",
+				},
+			},
+			wanted: search.NewNumericRangeQuery().Field("first_seen").Max(float32(time.Now().Add(-24*time.Hour).Unix()), true),
+		},
+		{
+			name:  "test relative time with days",
+			input: "fs >= 7d",
+			config: Config{
+				"fs": {
+					Type:  DATE,
+					Field: "first_seen",
+				},
+			},
+			wanted: search.NewNumericRangeQuery().Field("first_seen").Min(float32(time.Now().Add(-7*24*time.Hour).Unix()), true),
+		},
+		{
+			name:  "test relative time with minutes",
+			input: "ls <= 30m",
+			config: Config{
+				"ls": {
+					Type:  DATE,
+					Field: "last_seen",
+				},
+			},
+			wanted: search.NewNumericRangeQuery().Field("last_seen").Max(float32(time.Now().Add(-30*time.Minute).Unix()), true),
+		},
+		{
+			name:  "test relative time with years",
+			input: "fs >= 1y",
+			config: Config{
+				"fs": {
+					Type:  DATE,
+					Field: "first_seen",
+				},
+			},
+			wanted: search.NewNumericRangeQuery().Field("first_seen").Min(float32(time.Now().Add(-365*24*time.Hour).Unix()), true),
 		},
 	}
 

--- a/internal/query-parser/parser/parser.go
+++ b/internal/query-parser/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/saferwall/saferwall-api/internal/query-parser/token"
 )
@@ -212,11 +213,23 @@ func (p *Parser) applyUnitIfExist(ident token.Token) string {
 		return strconv.Itoa(math.MaxInt32)
 	}
 
-	units := map[string]int{
+	sizeUnits := map[string]int{
 		"kb": 1000,
 		"mb": 1000_000,
 		"gb": 1000_000_000,
 		"tb": 1000_000_000_000,
 	}
-	return strconv.Itoa(num * units[strings.ToLower(unit.Literal)])
+
+	dateUnits := map[string]time.Duration{
+		"m": time.Minute,
+		"h": time.Hour,
+		"d": 24 * time.Hour,
+		"y": 365 * 24 * time.Hour,
+	}
+
+	if v, ok := dateUnits[strings.ToLower(unit.Literal)]; ok {
+		return time.Now().Add(-time.Duration(num) * v).Format(time.RFC3339)
+	}
+
+	return strconv.Itoa(num * sizeUnits[strings.ToLower(unit.Literal)])
 }

--- a/internal/query-parser/token/token.go
+++ b/internal/query-parser/token/token.go
@@ -52,6 +52,12 @@ var sizeUnits = map[string]TokenType{
 	"mb": UNIT,
 	"gb": UNIT,
 	"tb": UNIT,
+
+	// date units
+	"m": UNIT,
+	"h": UNIT,
+	"d": UNIT,
+	"y": UNIT,
 }
 
 // Update LookupIdent to return both token type and value type


### PR DESCRIPTION
- Extend query parser to handle relative time units (m, h, d, y)
- Update lexer and parser to recognize and process time-based comparisons
- Add test cases for various relative time unit scenarios in query generation
- Modify token recognition to include date unit tokens

- [x] parser tests
- [x] gen tests