### PR TITLE
stream s3 file instead of buffer it all before returning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/swag v1.16.4
 	github.com/xhit/go-simple-mail/v2 v2.16.0
-	github.com/yeka/zip v0.0.0-20180914125537-d046722c6feb
+	github.com/yeka/zip v0.0.0-20231116150916-03d6312748a9
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/xhit/go-simple-mail/v2 v2.16.0 h1:ouGy/Ww4kuaqu2E2UrDw7SvLaziWTB60ICL
 github.com/xhit/go-simple-mail/v2 v2.16.0/go.mod h1:b7P5ygho6SYE+VIqpxA6QkYfv4teeyG4MKqB3utRu98=
 github.com/yeka/zip v0.0.0-20180914125537-d046722c6feb h1:OJYP70YMddlmGq//EPLj8Vw2uJXmrA+cGSPhXTDpn2E=
 github.com/yeka/zip v0.0.0-20180914125537-d046722c6feb/go.mod h1:9BnoKCcgJ/+SLhfAXj15352hTOuVmG5Gzo8xNRINfqI=
+github.com/yeka/zip v0.0.0-20231116150916-03d6312748a9 h1:K8gF0eekWPEX+57l30ixxzGhHH/qscI3JCnuhbN6V4M=
+github.com/yeka/zip v0.0.0-20231116150916-03d6312748a9/go.mod h1:9BnoKCcgJ/+SLhfAXj15352hTOuVmG5Gzo8xNRINfqI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -57,7 +57,8 @@ type Service interface {
 
 type UploadDownloader interface {
 	Upload(ctx context.Context, bucket, key string, file io.Reader) error
-	Download(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
+	Download(ctx context.Context, bucket, key string, file io.Writer) error
+	DownloadWithSize(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
 	Exists(ctx context.Context, bucket, key string) (bool, error)
 	GeneratePresignedURL(ctx context.Context, bucket, key string) (string, error)
 }
@@ -493,7 +494,7 @@ func (s service) DownloadRaw(ctx context.Context, sha256 string, file io.Writer)
 		return size, ErrObjectNotFound
 	}
 
-	size, err = s.objSto.Download(downloadCtx, s.bucket, sha256, file)
+	size, err = s.objSto.DownloadWithSize(downloadCtx, s.bucket, sha256, file)
 	if err != nil {
 		s.logger.With(ctx).Error(err)
 		return size, err
@@ -520,7 +521,7 @@ func (s service) Download(ctx context.Context, sha256 string, zipFile *string) e
 	}
 
 	buf := new(bytes.Buffer)
-	_, err = s.objSto.Download(downloadCtx, s.bucket, sha256, buf)
+	err = s.objSto.Download(downloadCtx, s.bucket, sha256, buf)
 	if err != nil {
 		s.logger.With(ctx).Error(err)
 		return err

--- a/internal/storage/local/local.go
+++ b/internal/storage/local/local.go
@@ -51,22 +51,50 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 
 // Download downloads an object from the local file system.
 func (s Service) Download(ctx context.Context, bucket, key string,
-	dst io.Writer) (int64, error) {
+	dst io.Writer) error {
 
 	// Create new file.
 	name := filepath.Join(s.root, bucket, key)
 	src, err := os.Open(name)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer src.Close()
 
 	// Perform the copy.
 	if _, err := io.Copy(dst, src); err != nil {
-		return 0, err
+		return err
 	}
 
-	return 0, nil
+	return nil
+}
+
+// Download downloads an object from the local file system.
+func (s Service) DownloadWithSize(ctx context.Context, bucket, key string,
+	dst io.Writer) (size int64, err error) {
+
+	// Create new file.
+	name := filepath.Join(s.root, bucket, key)
+	src, err := os.Open(name)
+
+	if err != nil {
+		return
+	}
+
+	defer src.Close()
+
+	fileInfo, err := src.Stat()
+
+	if err != nil {
+		return
+	}
+
+	// Perform the copy.
+	if _, err = io.Copy(dst, src); err != nil {
+		return
+	}
+
+	return fileInfo.Size(), err
 }
 
 // MakeBucket creates a new folder in the local file system that acts like

--- a/internal/storage/local/local.go
+++ b/internal/storage/local/local.go
@@ -51,22 +51,22 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 
 // Download downloads an object from the local file system.
 func (s Service) Download(ctx context.Context, bucket, key string,
-	dst io.Writer) error {
+	dst io.Writer) (int64, error) {
 
 	// Create new file.
 	name := filepath.Join(s.root, bucket, key)
 	src, err := os.Open(name)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer src.Close()
 
 	// Perform the copy.
 	if _, err := io.Copy(dst, src); err != nil {
-		return err
+		return 0, err
 	}
 
-	return nil
+	return 0, nil
 }
 
 // MakeBucket creates a new folder in the local file system that acts like

--- a/internal/storage/minio/minio.go
+++ b/internal/storage/minio/minio.go
@@ -63,23 +63,43 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 }
 
 func (s Service) Download(ctx context.Context, bucket, key string,
-	file io.Writer) (int64, error) {
+	file io.Writer) error {
 
 	reader, err := s.client.GetObject(ctx, bucket, key, mio.GetObjectOptions{})
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	stat, err := reader.Stat()
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	_, err = io.CopyN(file, reader, stat.Size)
 	if err != nil {
-		return 0, err
+		return err
 	}
-	return 0, nil
+	return nil
+}
+
+func (s Service) DownloadWithSize(ctx context.Context, bucket, key string,
+	file io.Writer) (size int64, err error) {
+
+	reader, err := s.client.GetObject(ctx, bucket, key, mio.GetObjectOptions{})
+	if err != nil {
+		return
+	}
+
+	stat, err := reader.Stat()
+	if err != nil {
+		return
+	}
+
+	_, err = io.CopyN(file, reader, stat.Size)
+	if err != nil {
+		return
+	}
+	return stat.Size, err
 }
 
 // MakeBucket creates a new bucket with bucketName with a context to control

--- a/internal/storage/minio/minio.go
+++ b/internal/storage/minio/minio.go
@@ -63,23 +63,23 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 }
 
 func (s Service) Download(ctx context.Context, bucket, key string,
-	file io.Writer) error {
+	file io.Writer) (int64, error) {
 
 	reader, err := s.client.GetObject(ctx, bucket, key, mio.GetObjectOptions{})
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	stat, err := reader.Stat()
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	_, err = io.CopyN(file, reader, stat.Size)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	return nil
+	return 0, nil
 }
 
 // MakeBucket creates a new bucket with bucketName with a context to control

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -91,7 +91,7 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 
 // Download downloads an object from s3.
 func (s Service) Download(ctx context.Context, bucket, key string,
-	file io.Writer) error {
+	file io.Writer) (int64, error) {
 
 	// Download input parameters.
 	input := &awss3.GetObjectInput{
@@ -100,9 +100,9 @@ func (s Service) Download(ctx context.Context, bucket, key string,
 	}
 
 	// Perform the download.
-	_, err := s.downloader.DownloadWithContext(ctx, FakeWriterAt{file}, input)
+	size, err := s.downloader.DownloadWithContext(ctx, FakeWriterAt{file}, input)
 
-	return err
+	return size, err
 }
 
 // MakeBucket creates a new bucket in s2.

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -107,7 +107,9 @@ func (s Service) Download(ctx context.Context, bucket, key string,
 
 // Download downloads an object from s3.
 func (s Service) DownloadWithSize(ctx context.Context, bucket, key string,
-	file io.Writer) (int64, error) {
+	file io.Writer, done func()) (int64, error) {
+
+	defer done()
 
 	// Download input parameters.
 	input := &awss3.GetObjectInput{

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -91,6 +91,22 @@ func (s Service) Upload(ctx context.Context, bucket, key string,
 
 // Download downloads an object from s3.
 func (s Service) Download(ctx context.Context, bucket, key string,
+	file io.Writer) error {
+
+	// Download input parameters.
+	input := &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	// Perform the download.
+	_, err := s.downloader.DownloadWithContext(ctx, FakeWriterAt{file}, input)
+
+	return err
+}
+
+// Download downloads an object from s3.
+func (s Service) DownloadWithSize(ctx context.Context, bucket, key string,
 	file io.Writer) (int64, error) {
 
 	// Download input parameters.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -27,7 +27,9 @@ type UploadDownloader interface {
 	// Upload uploads a file to an object storage.
 	Upload(ctx context.Context, bucket, key string, file io.Reader) error
 	// Download downloads a file from a remote object storage location.
-	Download(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
+	Download(ctx context.Context, bucket, key string, file io.Writer) error
+	// DownloadWithSize downloads a file from a remote object storage location and returns it's size.
+	DownloadWithSize(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
 	// MakeBucket creates a new bucket.
 	MakeBucket(ctx context.Context, bucket, location string) error
 	// Exists checks whether an object exists.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -29,7 +29,7 @@ type UploadDownloader interface {
 	// Download downloads a file from a remote object storage location.
 	Download(ctx context.Context, bucket, key string, file io.Writer) error
 	// DownloadWithSize downloads a file from a remote object storage location and returns it's size.
-	DownloadWithSize(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
+	DownloadWithSize(ctx context.Context, bucket, key string, file io.Writer, done func ()) (int64, error)
 	// MakeBucket creates a new bucket.
 	MakeBucket(ctx context.Context, bucket, location string) error
 	// Exists checks whether an object exists.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -27,7 +27,7 @@ type UploadDownloader interface {
 	// Upload uploads a file to an object storage.
 	Upload(ctx context.Context, bucket, key string, file io.Reader) error
 	// Download downloads a file from a remote object storage location.
-	Download(ctx context.Context, bucket, key string, file io.Writer) error
+	Download(ctx context.Context, bucket, key string, file io.Writer) (int64, error)
 	// MakeBucket creates a new bucket.
 	MakeBucket(ctx context.Context, bucket, location string) error
 	// Exists checks whether an object exists.


### PR DESCRIPTION
- updated yeka/zip to latest
- modified interfaces to return size of the download with the error where appropriate
- updated v1/files/[sha256]/download endpoint to stream file from s3 into the zip function, and from zip function into the response using an io.Pipe()